### PR TITLE
Decrease event processing latency

### DIFF
--- a/config/device.py
+++ b/config/device.py
@@ -276,7 +276,6 @@ class Device:
 					threading.Thread( target=currentEvent.press ).start()
 					if self.queue:
 						self.queue.pop( 0 )
-					time.sleep( self.comboDelay )
 			except IndexError:
 				pass	
 				

--- a/config/device.py
+++ b/config/device.py
@@ -246,7 +246,7 @@ class Device:
 		for event in self.pinEvents[ channel ]:
 			if event.bitmaskIn( gpioBitmask ):
 				with self.queueLock:
-				    self.queue.append( event )
+					self.queue.append( event )
 				gpioBitmask &= ~event.bitmask
 		# start queue processing
 		if not self.processing:

--- a/config/device.py
+++ b/config/device.py
@@ -158,6 +158,7 @@ class Device:
 		#Every event is called based on the pins it contains
 		self.pinEvents = { pin:[] for pin in AVAILABLE_PINS }
 		self.queue = []
+		self.queueLock = threading.Lock()
 		self.processing = False
 		self.comboDelay = args.combo_delay
 		self.processTimer = threading.Timer( self.comboDelay, self.processQueue )
@@ -244,7 +245,8 @@ class Device:
 	def pressEvents( self, gpioBitmask, channel ):
 		for event in self.pinEvents[ channel ]:
 			if event.bitmaskIn( gpioBitmask ):
-				self.queue.append( event )
+				with self.queueLock:
+				    self.queue.append( event )
 				gpioBitmask &= ~event.bitmask
 		# start queue processing
 		if not self.processing:
@@ -260,24 +262,26 @@ class Device:
 		''' 
 			This method processes press events as they enter the queue
 		'''
-		while self.queue:
-			try:
-				currentEvent = self.queue[ 0 ]
-				currentBitmask = currentEvent.bitmask
-				for event in self.queue[ 1: ]:
-					# check if button is part of combo press
-					if currentEvent.bitmaskIn( event.bitmask ):
-						# remove currentEvent
-						self.queue.pop(0)
-						break
-				else:
-					# run the method
-					self.DEBUG( 'Press ' + currentEvent.name )
-					threading.Thread( target=currentEvent.press ).start()
-					if self.queue:
-						self.queue.pop( 0 )
-			except IndexError:
-				pass	
+
+		while True:
+			with self.queueLock:
+				if not self.queue:
+					break
+				currentEvent = self.queue.pop(0)
+
+				try:
+					currentBitmask = currentEvent.bitmask
+					for event in self.queue:
+						# check if button is part of combo press
+						if currentEvent.bitmaskIn( event.bitmask ):
+							break
+					else:
+						# run the method
+						self.DEBUG( 'Press ' + currentEvent.name )
+						threading.Thread( target=currentEvent.press ).start()
+						
+				except IndexError:
+					pass	
 				
 		self.processTimer = threading.Timer( self.comboDelay, self.processQueue )
 		self.processing = False

--- a/gpionext.py
+++ b/gpionext.py
@@ -85,7 +85,7 @@ class GPIOnext:
 		
 	def set_args( self ):
 		self.args.pins = [ int(x) for x in self.args.pins.split(',') ]
-		self.args.combo_delay = (self.args.debounce + self.args.combo_delay) / 1000
+		self.args.combo_delay = self.args.combo_delay / 1000
 		if self.args.debug:
 			__location__ = os.path.realpath( os.path.join(os.getcwd(), os.path.dirname(__file__)) )
 			self.args.log = open( os.path.join(__location__, 'logFile.txt'),'w' ) 


### PR DESCRIPTION
Some time ago, I assembled a Retropie arcade machine, combining a Raspberry PI with [this case](https://www.jaycar.co.nz/raspberry-pi-retro-arcade-game-console-with-hdmi-port/p/XC9062):

![image](https://user-images.githubusercontent.com/1272094/230537399-0fe25620-f0b4-4037-8770-96f5838efeb4.png)

The manual for the case includes instructions to clone the GPIONext repo.

We've found the arcade machine great fun to play, but some friends commented on a feeling of lag playing some of the games. After many false starts, investigation of that led to this PR.

With these changes in place, there is no perceptible lag - and I doubled my high score on an old favourite. 😁 

The changes are:

* Removing an extraneous sleep from `device.py` that can cause event processing to be significantly delayed. 

* Remove extra use of the button debounce delay, as the gpio library already handles that.

* Add locks around access to the queue of events, to ensure no events are lost to thread concurrency.

My intuition is that the additional `sleep()` may have been added to try and prevent events from being lost. Given that python lists are not safe for concurrent modification, event loss was possible if `pressEvents()` and `processQueue()` both tried to modify `queue` at the same time. Adding locks around access to `queue` should prevent this from happening.

I've included below a detailed analysis of the worst-case lag and how that's addressed by these changes.


## Analysis

This analysis is in two parts. The first documents current behavour of the `master` branch as of commit `2626e5c`; the second shows how the changes in this PR reduce lag.

### Assumptions

Combo delay using the default of 50ms (ref: gpionext.py L#17)
Button debounce using the default of 20ms (ref: gpionext.py L#26)
Event timer using the sum of combo delay and button debounce, 70ms (ref: gpionext.py L#88)

Button press events occurring every 130ms, this interval chosen to demonstrate worst case lag.

### Current behaviour

| Timestamp | Event                | Actions                             | device.py |
| :-------: | :------------------- | :---------------------------------- | --------: |
|     t     | Button press B0      | Event added to queue                |     L#247 |
|           |                      | 70ms event timer started            |     L#254 |
| t + 70ms  | Event timer triggers | Event timer triggers processQueue() |     L#259 |
|           |                      | B0 dispatched after 70ms            |     L#276 |
|           |                      | Sleep of 70ms starts                |     L#279 |
| t + 130ms | Button press B1      | Event added to queue                |     L#247 |
|           |                      | Timer already started               |     L#257 |
| t + 140ms |                      | Sleep of 70ms ends                  |           |
|           |                      | Timer reset                         |     L#283 |
| t + 260ms | Button press B2      | Event added to queue                |     L#247 |
|           |                      | 70ms event timer started            |     L#254 |
| t + 330ms | Event timer triggers | Event timer triggers processQueue() |     L#259 |
|           |                      | B1 dispatched after 200ms           |     L#276 |
|           |                      | B2 dispatched after 70ms            |     L#276 |
|           |                      | Sleep of 70ms starts                |     L#279 |
| t + 390ms |                      | Sleep of 70ms ends                  |           |
|           |                      | Timer reset                         |     L#283 |

The 200ms delay in dispatching Button press B1 (1/5 of a second) is long enough to impair playability of arcade games in which players routinely use split second timing.


### New behaviour

| Timestamp | Event                | Actions                             | device.py |
| :-------: | :------------------- | :---------------------------------- | --------: |
|     t     | Button press B0      | Event added to queue                |     L#247 |
|           |                      | 70ms event timer started            |     L#254 |
| t + 70ms  | Event timer triggers | Event timer triggers processQueue() |     L#259 |
|           |                      | B0 dispatched after 70ms            |     L#276 |
|           |                      | Timer reset                         |     L#283 |
| t + 130ms | Button press B1      | Event added to queue                |     L#247 |
|           |                      | 70ms event timer started            |     L#254 |
| t + 200ms | Event timer triggers | Event timer triggers processQueue() |     L#259 |
|           |                      | B1 dispatched after 70ms            |     L#276 |
|           |                      | Timer reset                         |     L#283 |
| t + 260ms | Button press B2      | Event added to queue                |     L#247 |
|           |                      | 70ms event timer started            |     L#254 |
| t + 330ms | Event timer triggers | Event timer triggers processQueue() |     L#259 |
|           |                      | B2 dispatched after 70ms            |     L#276 |
|           |                      | Timer reset                         |     L#283 |


