### PR TITLE
Use GPIO BCM mode to allow use of GPIO 0 and 1

### DIFF
--- a/config/constants.py
+++ b/config/constants.py
@@ -3,7 +3,7 @@ from evdev import AbsInfo, ecodes as e
 import RPi.GPIO as GPIO
 
 #Pi Zero, 1, 2, OR 3 - (Versions A+/B+)
-AVAILABLE_PINS = (2,3,4,5,6,7,8,9,10,11,12,13,14,16,17,18,19,20,21,22,23,24,25,26,27)
+AVAILABLE_PINS = (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27)
 
 #Pi 1 (Versions A/B)
 if GPIO.RPI_INFO['P1_REVISION'] < 3:

--- a/config/constants.py
+++ b/config/constants.py
@@ -3,34 +3,32 @@ from evdev import AbsInfo, ecodes as e
 import RPi.GPIO as GPIO
 
 #Pi Zero, 1, 2, OR 3 - (Versions A+/B+)
-AVAILABLE_PINS = (3,5,7,11,13,15,19,21,23,29,31,33,35,37,
-			8,10,12,16,18,22,24,26,32,36,38,40)
+AVAILABLE_PINS = (2,3,4,5,6,7,8,9,10,11,12,13,14,16,17,18,19,20,21,22,23,24,25,26,27)
 
 #Pi 1 (Versions A/B)
 if GPIO.RPI_INFO['P1_REVISION'] < 3:
-	AVAILABLE_PINS = (3,5,7,11,13,15,19,21,23,
-				8,10,12,16,18,22,24,26)
+	AVAILABLE_PINS = (2,3,4,7,8,9,10,11,14,15,17,18,22,23,24,25,27)
 
 AVAILABLE_PINS_STRING = ', '.join(map(str, AVAILABLE_PINS))
 
 JOYSTICK_AXIS = AbsInfo(
-										value = 0, 
-										min = -255, 
-										max = 255, 
-										fuzz = 0, 
-										flat = 15, 
+										value = 0,
+										min = -255,
+										max = 255,
+										fuzz = 0,
+										flat = 15,
 										resolution = 0
 									)
 
 DEVICE_LIST = [
-					'Joypad 1', 
-					'Joypad 2', 
-					'Joypad 3', 
-					'Joypad 4', 
-					'Keyboard', 
+					'Joypad 1',
+					'Joypad 2',
+					'Joypad 3',
+					'Joypad 4',
+					'Keyboard',
 					'Commands'
 					]
-					
+
 BUTTON_LIST =[
 	('Start Button', e.BTN_START),
 	('Select Button', e.BTN_SELECT),
@@ -136,7 +134,7 @@ ALL_JOYSTICK_BUTTONS = [
 	e.BTN_TRIGGER_HAPPY38,
 	e.BTN_TRIGGER_HAPPY39,
 	e.BTN_TRIGGER_HAPPY40]
-	
+
 KEY_LIST = [
 	('↑ UP', e.KEY_UP),
 	('↓ DOWN', e.KEY_DOWN),

--- a/config/gpio.py
+++ b/config/gpio.py
@@ -21,17 +21,17 @@ def registerDevices( devices ):
 	for device in devices:
 		pinPressMethods.append( device.pressEvents )
 		#pinReleaseMethods.append( device.releaseEvents )
-			
+
 def onPinChange( channel ):
 	global pinChangeMethods, bitmask
 	for method in pinChangeMethods:
 		method( bitmask, channel )
-		
+
 def onPinPress( channel ):
 	global pinPressMethods, bitmask
 	for method in pinPressMethods:
 		method( bitmask, channel )
-		
+
 def onPinRelease( channel ):
 	global pinReleaseMethods, bitmask
 	for method in pinReleaseMethods:
@@ -47,7 +47,7 @@ def bitmaskToList():
 	return [ x for x in range(41) if bitmaskContains(x) ]
 
 class pin:
-	
+
 	def __init__( self, number, pull, args ):
 		self.number = number
 		self.pull = pull
@@ -55,8 +55,8 @@ class pin:
 		try:
 			if GPIO.gpio_function(self.number) == GPIO.IN:
 				GPIO.setup(number, GPIO.IN, pull_up_down=pull)
-				GPIO.add_event_detect(	self.number, 
-										GPIO.BOTH, 
+				GPIO.add_event_detect(	self.number,
+										GPIO.BOTH,
 										callback = self.set_bitmask,
 										bouncetime = args.debounce)
 			else:
@@ -65,7 +65,7 @@ class pin:
 			print(f"Can't add edge detection for pin {self.number}(pin is already in use). Skipping.")
 		except ValueError:
 			print(f"{self.number} is an invalid pin number!")
-	
+
 	def set_bitmask( self, channel ):
 		global bitmask
 		global changedState
@@ -77,26 +77,26 @@ class pin:
 			bitmask &= ~( self.bit ) #remove channel
 			onPinRelease( channel )
 		onPinChange( channel )
-			
+
 	def button_pressed( self ):
 		time.sleep( 0.01 )
 		#22 = pressed
 		#LOW->0 + PULLUP->22 = 22
 		#HIGH->1 + PULLDOWN->21 = 22
 		return GPIO.input( self.number ) + self.pull == 22
-		
+
 def cleanup():
 	global pins
 	pinList = [p.number for p in pins]
 	for p in pins:
 		GPIO.remove_event_detect(p.number)
 	GPIO.cleanup(pinList)
-	
+
 def setupGPIO( args ):
 	global pins
-	GPIO.setmode(GPIO.BOARD)
+	GPIO.setmode(GPIO.BCM)
 	GPIO.setwarnings(args.dev)
-	pull = GPIO.PUD_UP 
+	pull = GPIO.PUD_UP
 	if args.pulldown:
 		pull = GPIO.PUD_DOWN
 	for pinNumber in args.pins:
@@ -105,4 +105,3 @@ def setupGPIO( args ):
 				print("Can't set I2C pins to pulldown! Skipping...")
 				continue
 		pins.append( pin(pinNumber, pull, args) )
-		


### PR DESCRIPTION
rpi.GPIO is being used in BOARD mode, which doesn't allow BCM pins 0 and 1 (board pins 27 and 28) to be used. Changing it to BCM mode resolves this issue. Some existing Raspberry pi-based emulator hardware (ex: Mintypi) have buttons connected to these pins.